### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   test:
     name: Run Tests
+    permissions:
+      contents: read
     runs-on: ubuntu-latest  # Use Ubuntu Linux environment
 
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/portfedh/codi-api/security/code-scanning/10](https://github.com/portfedh/codi-api/security/code-scanning/10)

To fix this problem, explicitly add a `permissions` block with minimal privileges. In this case, since the workflow only needs to read repository contents (for checkout and running tests) and upload artifacts, and does not perform actions that require write access (e.g., creating issues, PRs, or pushing commits), the recommended permission is `contents: read`. This should be added at the job-level for the `test` job (line 15), ensuring job specificity. No code logic or step functionality is impacted by this change—it only restricts the GitHub token's capabilities as used by this job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
