### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/portfedh/codi-api/security/code-scanning/1](https://github.com/portfedh/codi-api/security/code-scanning/1)

To fix this problem, an explicit `permissions` block should be added to limit the permissions granted to the `GITHUB_TOKEN` within the workflow. Since this workflow's only step is executing remote commands over SSH and does not perform any GitHub Actions requiring repository or other GitHub API privileges, the strictest setting is to set `permissions: {}` at the workflow or job level. This will set the `GITHUB_TOKEN` to have no permissions. This change should be added at the top level of the workflow (just after the `name:` or after `on:` block), or specifically within the affected job, above `runs-on:`. Both placements are valid; placing at the root is preferred if all jobs need this restriction.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
